### PR TITLE
Add ManyToOne fields to alias

### DIFF
--- a/features/src/codegen/features/domain/InheritanceASubOneAlias.java
+++ b/features/src/codegen/features/domain/InheritanceASubOneAlias.java
@@ -19,6 +19,7 @@ public class InheritanceASubOneAlias extends Alias<InheritanceASubOne> {
   public final IdAliasColumn<InheritanceABase> id;
   public final StringAliasColumn<InheritanceABase> name;
   public final LongAliasColumn<InheritanceABase> version;
+  public final ForeignKeyAliasColumn<InheritanceABase, InheritanceAOwner> inheritanceAOwner;
 
   public InheritanceASubOneAlias() {
     this("iaso0", null, true);
@@ -36,6 +37,7 @@ public class InheritanceASubOneAlias extends Alias<InheritanceASubOne> {
     this.id = this.baseAlias.id;
     this.name = this.baseAlias.name;
     this.version = this.baseAlias.version;
+    this.inheritanceAOwner = this.baseAlias.inheritanceAOwner;
   }
 
   public List<AliasColumn<InheritanceASubOne, ?, ?>> getColumns() {

--- a/features/src/codegen/features/domain/InheritanceASubTwoAlias.java
+++ b/features/src/codegen/features/domain/InheritanceASubTwoAlias.java
@@ -19,6 +19,7 @@ public class InheritanceASubTwoAlias extends Alias<InheritanceASubTwo> {
   public final IdAliasColumn<InheritanceABase> id;
   public final StringAliasColumn<InheritanceABase> name;
   public final LongAliasColumn<InheritanceABase> version;
+  public final ForeignKeyAliasColumn<InheritanceABase, InheritanceAOwner> inheritanceAOwner;
 
   public InheritanceASubTwoAlias() {
     this("iast0", null, true);
@@ -36,6 +37,7 @@ public class InheritanceASubTwoAlias extends Alias<InheritanceASubTwo> {
     this.id = this.baseAlias.id;
     this.name = this.baseAlias.name;
     this.version = this.baseAlias.version;
+    this.inheritanceAOwner = this.baseAlias.inheritanceAOwner;
   }
 
   public List<AliasColumn<InheritanceASubTwo, ?, ?>> getColumns() {

--- a/features/src/test/java/features/domain/InheritanceAQueryTest.java
+++ b/features/src/test/java/features/domain/InheritanceAQueryTest.java
@@ -46,7 +46,7 @@ public class InheritanceAQueryTest {
   }
 
   @Test
-  public void testFindSubOnelsoFindsBase() {
+  public void testFindSubOneAlsoFindsBase() {
     InheritanceASubOneAlias sa = new InheritanceASubOneAlias("sa");
     Select<InheritanceASubOne> q = Select.from(sa);
     q.where(sa.one.eq("one"));
@@ -59,5 +59,21 @@ public class InheritanceAQueryTest {
       " INNER JOIN \"inheritance_a_base\" sa_b ON sa.id = sa_b.id",
       " WHERE sa.one = ?"), q.toSql());
     Assert.assertEquals(Copy.list("one"), q.getWhere().getParameters());
+  }
+
+  @Test
+  public void testFindSubOneWithFilterOnBase() {
+    InheritanceASubOneAlias sa = new InheritanceASubOneAlias("sa");
+    Select<InheritanceASubOne> q = Select.from(sa);
+    q.where(sa.inheritanceAOwner.eq(1L));
+
+    Assert.assertEquals(Join.lines(//
+      "SELECT"//
+        + " sa_b.id, sa_b.name, sa_b.version, sa_b.inheritance_a_owner_id,"
+        + " sa.one, sa.inheritance_a_thing_id",
+      " FROM \"inheritance_a_sub_one\" sa",
+      " INNER JOIN \"inheritance_a_base\" sa_b ON sa.id = sa_b.id",
+      " WHERE sa_b.inheritance_a_owner_id = ?"), q.toSql());
+    Assert.assertEquals(Copy.list(1L), q.getWhere().getParameters());
   }
 }

--- a/migrations/src/main/java/joist/codegen/passes/GenerateAliasesPass.java
+++ b/migrations/src/main/java/joist/codegen/passes/GenerateAliasesPass.java
@@ -79,6 +79,16 @@ public class GenerateAliasesPass implements Pass<Codegen> {
         this.appendToConstructors(aliasClass, "this.{} = this.baseAlias.{};", p.getVariableName(), p.getVariableName());
       }
 
+      for (ManyToOneProperty p : baseEntity.getManyToOneProperties()) {
+        Class<?> aliasColumnClass = (p.getOneSide().isCodeEntity()) ? CodeAliasColumn.class : ForeignKeyAliasColumn.class;
+        aliasClass.addImports(aliasColumnClass);
+        aliasClass.addImports(p.getOneSide().getFullClassName());
+
+        GField field = aliasClass.getField(p.getVariableName()).setPublic().setFinal();
+        field.type("{}<{}, {}>", aliasColumnClass.getSimpleName(), p.getManySide().getClassName(), p.getJavaType());
+        this.appendToConstructors(aliasClass, "this.{} = this.baseAlias.{};", p.getVariableName(), p.getVariableName());
+      }
+
       aliasClass.addImports(entity.getConfig().getDomainObjectPackage() + "." + baseEntity.getClassName());
       baseEntity = baseEntity.getBaseEntity();
     }


### PR DESCRIPTION
Before only the primitive fields of a base class appeared in a subclass's alias. This applies the same patter to the many-to-one attributes.
