### PR TITLE
Handle nulls in DataTransferObjectMapper

### DIFF
--- a/domain/src/main/java/joist/domain/orm/mappers/DataTransferObjectMapper.java
+++ b/domain/src/main/java/joist/domain/orm/mappers/DataTransferObjectMapper.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import joist.domain.DomainObject;
 import joist.domain.orm.queries.SelectItem;
-import joist.domain.orm.queries.columns.ColumnExpression;
 import joist.jdbc.RowMapper;
 
 public class DataTransferObjectMapper<T extends DomainObject, R> implements RowMapper {
@@ -38,7 +37,12 @@ public class DataTransferObjectMapper<T extends DomainObject, R> implements RowM
         Field field = this.rowType.getField(item.getAs());
         Object value;
         if (item.getColumn() != null) {
-          value = ((ColumnExpression<?, ?>) item.getColumn()).toJdbcValue(rs, rs.findColumn(item.getAs()));
+          int column = rs.findColumn(item.getAs());
+          if (rs.getObject(column) == null) {
+            value = null;
+          } else {
+            value = item.getColumn().toDomainValue(rs, column);
+          }
         } else {
           value = rs.getObject(item.getAs());
         }

--- a/domain/src/main/java/joist/domain/orm/queries/columns/AliasColumn.java
+++ b/domain/src/main/java/joist/domain/orm/queries/columns/AliasColumn.java
@@ -41,10 +41,6 @@ public abstract class AliasColumn<T extends DomainObject, U, V> extends ColumnEx
 
   public abstract V toJdbcValue(ResultSet rs, int i) throws SQLException;
 
-  public U toDomainValue(V jdbcValue) {
-    return (U) jdbcValue;
-  }
-
   public V toJdbcValue(U domainValue) {
     return (V) domainValue;
   }

--- a/domain/src/main/java/joist/domain/orm/queries/columns/ColumnExpression.java
+++ b/domain/src/main/java/joist/domain/orm/queries/columns/ColumnExpression.java
@@ -13,6 +13,14 @@ public abstract class ColumnExpression<U, V> {
 
   public abstract V toJdbcValue(ResultSet rs, int i) throws SQLException;
 
+  public U toDomainValue(V jdbcValue) {
+    return (U) jdbcValue;
+  }
+
+  public U toDomainValue(ResultSet rs, int i) throws SQLException {
+    return this.toDomainValue(this.toJdbcValue(rs, i));
+  }
+
   public abstract String getQualifiedName();
 
   public Where lessThanOrEqual(U value) {

--- a/features/src/main/java/features/domain/queries/PrimitivesBQueries.java
+++ b/features/src/main/java/features/domain/queries/PrimitivesBQueries.java
@@ -1,5 +1,57 @@
 package features.domain.queries;
 
+import java.util.List;
+
+import joist.domain.orm.queries.Select;
+import joist.domain.orm.queries.columns.Aggregate;
+import features.domain.PrimitivesBAlias;
+
 public class PrimitivesBQueries extends PrimitivesBQueriesCodegen {
 
+  public List<PrimitivesBDto> asDtos() {
+    PrimitivesBAlias p = new PrimitivesBAlias();
+    return Select
+      .from(p)
+      .select(
+        p.id.as("id"),
+        p.bool1.as("bool1"),
+        p.bool2.as("bool2"),
+        p.int1.as("int1a"),
+        p.int2.as("int2a"),
+        p.small1.as("small1"),
+        p.small2.as("small2"),
+        p.big1.as("big1"),
+        p.big2.as("big2"))
+      .list(PrimitivesBDto.class);
+  }
+
+  public Short sumShort() {
+    PrimitivesBAlias p = new PrimitivesBAlias();
+    return Select.from(p).select(Aggregate.sum(p.small1).as("sumSmall")).list(SumResult.class).get(0).sumSmall;
+  }
+
+  public Long countShort() {
+    PrimitivesBAlias p = new PrimitivesBAlias();
+    return Select.from(p).select(Aggregate.count(p.small1).as("countSmall")).list(CountResult.class).get(0).countSmall;
+  }
+
+  public static class PrimitivesBDto {
+    public Long id;
+    public Boolean bool1;
+    public Boolean bool2;
+    public Integer int1a; // int1 is a keyword so add an extra letter
+    public Integer int2a; // int2 is a keyword
+    public Short small1;
+    public Short small2;
+    public Long big1;
+    public Long big2;
+  }
+
+  public static class SumResult {
+    public Short sumSmall;
+  }
+
+  public static class CountResult {
+    public Long countSmall;
+  }
 }

--- a/features/src/test/java/features/domain/PrimitivesBAggregatesTest.java
+++ b/features/src/test/java/features/domain/PrimitivesBAggregatesTest.java
@@ -1,0 +1,24 @@
+package features.domain;
+
+import static features.domain.builders.Builders.aPrimitivesB;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class PrimitivesBAggregatesTest extends AbstractFeaturesTest {
+
+  @Test
+  public void testSumSmallInt() {
+    aPrimitivesB().small1((short) 10).defaults();
+    this.commitAndReOpen();
+    assertThat(PrimitivesB.queries.sumShort(), is((short) 10));
+  }
+
+  @Test
+  public void testCountSmallInt() {
+    aPrimitivesB().small1((short) 10).defaults();
+    this.commitAndReOpen();
+    assertThat(PrimitivesB.queries.countShort(), is(1L));
+  }
+}

--- a/features/src/test/java/features/domain/PrimitivesBTest.java
+++ b/features/src/test/java/features/domain/PrimitivesBTest.java
@@ -1,15 +1,56 @@
 package features.domain;
 
-import org.junit.Assert;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
 import org.junit.Test;
+
+import features.domain.queries.PrimitivesBQueries.PrimitivesBDto;
 
 public class PrimitivesBTest extends AbstractFeaturesTest {
 
   @Test
   public void testNullables() {
     PrimitivesB p = new PrimitivesB();
-    Assert.assertFalse(p.getBoolNullableWithDefaultFalse());
+    assertThat(p.getBoolNullableWithDefaultFalse(), is(false));
 
+    this.setFields(p);
+    this.commitAndReOpen();
+
+    p = this.reload(p);
+    assertThat(p.getBool1(), is(nullValue()));
+    assertThat(p.getBool2(), is(true));
+    assertThat(p.getBoolWithDefaultTrue(), is(true));
+    assertThat(p.getBoolNullableWithDefaultFalse(), nullValue());
+    assertThat(p.getInt1(), is(nullValue()));
+    assertThat(p.getInt2().intValue(), is(2));
+    assertThat(p.getSmall1(), is(nullValue()));
+    assertThat(p.getSmall2().intValue(), is(2));
+    assertThat(p.getBig1(), is(nullValue()));
+    assertThat(p.getBig2(), is(Long.MAX_VALUE));
+  }
+
+  @Test
+  public void testNullablesInDataTransferObject() {
+    PrimitivesB p = new PrimitivesB();
+    this.setFields(p);
+    this.commitAndReOpen();
+    List<PrimitivesBDto> dtos = PrimitivesB.queries.asDtos();
+    PrimitivesBDto dto = dtos.get(0);
+    assertThat(dto.bool1, is(nullValue()));
+    assertThat(dto.bool2, is(true));
+    assertThat(dto.int1a, is(nullValue()));
+    assertThat(dto.int2a.intValue(), is(2));
+    assertThat(dto.small1, is(nullValue()));
+    assertThat(dto.small2.intValue(), is(2));
+    assertThat(dto.big1, is(nullValue()));
+    assertThat(dto.big2, is(Long.MAX_VALUE));
+  }
+
+  private void setFields(PrimitivesB p) {
     p.setBool1(null);
     p.setBool2(true);
     p.setBoolNullableWithDefaultFalse(null);
@@ -19,17 +60,6 @@ public class PrimitivesBTest extends AbstractFeaturesTest {
     p.setSmall2((short) 2);
     p.setBig1(null);
     p.setBig2(Long.MAX_VALUE);
-    this.commitAndReOpen();
-
-    p = this.reload(p);
-    Assert.assertTrue(p.getBool2());
-    Assert.assertTrue(p.getBoolWithDefaultTrue());
-    Assert.assertNull(p.getBoolNullableWithDefaultFalse());
-    Assert.assertNull(p.getInt1());
-    Assert.assertEquals(2, p.getInt2().intValue());
-    Assert.assertNull(p.getSmall1());
-    Assert.assertEquals(2, p.getSmall2().intValue());
-    Assert.assertNull(p.getBig1());
-    Assert.assertEquals(Long.MAX_VALUE, p.getBig2().longValue());
   }
+
 }

--- a/migrations/ivy.xml
+++ b/migrations/ivy.xml
@@ -11,6 +11,6 @@
 		<dependency org="joist" name="joist-domain" rev="${joist.version}" conf="compile"/>
 		<dependency org="junit" name="junit" rev="4.10" conf="test"/>
 
-		<dependency org="org.projectlombok" name="lombok" rev="0.10.0-201104011955" conf="provided"/>
+		<dependency org="org.projectlombok" name="lombok" rev="0.10.2" conf="provided"/>
 	</dependencies>
 </ivy-module>


### PR DESCRIPTION
DataTransferObjectMapper was using toJdbcValue when it should have been using toDomainValue. This forced a tweak of aggregate generics to handle SmallInt. SmallInt is a good test because it has a different domain and JDBC type. Some extra code was needed to add toDomainValue to aggregates. I also needed to add toDomainValue(ResultSet, int) helper to ColumnExpression defined as toDomainValue(toJdbcValue(ResultSet, int)) so the generics type check correctly in DataTransferObjectMapper. I tried putting toDomainValue(toJdbcValue(ResultSet, int)) directly in DataTransferObjectMapper, but they were being called on ColumnExpression<?, ?> and Java's type capture did not recognize that the return value of toJdbcValue was the same type as the argument of toDomainValue.
