### PR TITLE
Added Charset arg to Write and Read

### DIFF
--- a/migrations/src/main/java/joist/codegen/passes/OutputPass.java
+++ b/migrations/src/main/java/joist/codegen/passes/OutputPass.java
@@ -1,12 +1,13 @@
 package joist.codegen.passes;
 
 import java.io.File;
-
-import joist.codegen.Codegen;
-import joist.util.Read;
+import java.nio.charset.Charset;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import joist.codegen.Codegen;
+import joist.util.Read;
 
 public class OutputPass implements Pass<Codegen> {
 
@@ -27,7 +28,7 @@ public class OutputPass implements Pass<Codegen> {
       for (File directory : codegen.getOutputSourceDirectory().getUsedDirectories()) {
         for (File file : directory.listFiles()) {
           if (file.isFile() && !codegen.getOutputSourceDirectory().getTouched().contains(file)) {
-            String contents = Read.fromFile(file);
+            String contents = Read.fromFile(file, Charset.defaultCharset());
             String className = file.getName().replaceAll("\\.[a-zA-Z]+", "");
             String codegenName = className + "Codegen";
             if (contents.contains(className + " extends " + codegenName)) {

--- a/util/src/main/java/joist/sourcegen/GDirectory.java
+++ b/util/src/main/java/joist/sourcegen/GDirectory.java
@@ -1,16 +1,17 @@
 package joist.sourcegen;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import joist.util.Copy;
 import joist.util.Interpolate;
 import joist.util.Read;
 import joist.util.Write;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class GDirectory {
 
@@ -18,9 +19,15 @@ public class GDirectory {
   private final File directory;
   private final List<GClass> classes = new ArrayList<GClass>();
   private final List<File> touched = new ArrayList<File>();
+  private final Charset charset;
 
   public GDirectory(String directory) {
+    this(directory, Charset.defaultCharset());
+  }
+
+  public GDirectory(String directory, Charset charset) {
     this.directory = new File(directory);
+    this.charset = charset;
   }
 
   public GClass getClass(String _fullClassName, Object... args) {
@@ -45,7 +52,7 @@ public class GDirectory {
 
       File file = this.getFile(gc);
       if (file.exists()) {
-        String existingCode = Read.fromFile(file);
+        String existingCode = Read.fromFile(file, this.charset);
         if (newCode.equals(existingCode)) {
           this.touched.add(file);
           continue;
@@ -54,7 +61,7 @@ public class GDirectory {
 
       file.getParentFile().mkdirs();
       log.info("Saving {}", file);
-      Write.toFile(file, newCode);
+      Write.toFile(file, newCode, this.charset);
       this.touched.add(file);
     }
   }

--- a/util/src/main/java/joist/util/Read.java
+++ b/util/src/main/java/joist/util/Read.java
@@ -5,13 +5,14 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 
 public class Read {
 
-  public static String fromClasspath(String path) {
+  public static String fromClasspath(String path, Charset charset) {
     try {
       InputStream in = Read.class.getResourceAsStream(path);
-      String content = Read.fromInputStream(in);
+      String content = Read.fromInputStream(in, charset);
       in.close();
       return content;
     } catch (IOException e) {
@@ -19,25 +20,25 @@ public class Read {
     }
   }
 
-  public static String fromFile(String path) {
-    return fromFile(new File(path));
+  public static String fromFile(String path, Charset charset) {
+    return fromFile(new File(path), charset);
   }
 
-  public static String fromFile(File file) {
+  public static String fromFile(File file, Charset charset) {
     try {
-      return Read.fromInputStream(new FileInputStream(file));
+      return Read.fromInputStream(new FileInputStream(file), charset);
     } catch (FileNotFoundException e) {
       throw new IllegalArgumentException(e);
     }
   }
 
-  public static String fromInputStream(InputStream in) {
+  public static String fromInputStream(InputStream in, Charset charset) {
     try {
       StringBuilder content = new StringBuilder();
       int read;
       byte[] buffer = new byte[1024];
       while ((read = in.read(buffer)) != -1) {
-        content.append(new String(buffer, 0, read, "UTF-8"));
+        content.append(new String(buffer, 0, read, charset));
       }
       return content.toString();
     } catch (IOException io) {

--- a/util/src/main/java/joist/util/Write.java
+++ b/util/src/main/java/joist/util/Write.java
@@ -5,6 +5,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 
 public class Write {
 
@@ -22,15 +23,15 @@ public class Write {
     }
   }
 
-  public static void toFile(String path, String content) {
-    Write.toFile(new File(path), content);
+  public static void toFile(String path, String content, Charset charset) {
+    Write.toFile(new File(path), content, charset);
   }
 
-  public static void toFile(File file, String content) {
+  public static void toFile(File file, String content, Charset charset) {
     file.getParentFile().mkdirs();
     try {
       OutputStream out = new FileOutputStream(file);
-      out.write(content.getBytes());
+      out.write(content.getBytes(charset));
       out.flush();
       out.close();
     } catch (IOException io) {

--- a/util/src/test/java/joist/util/ExecuteTest.java
+++ b/util/src/test/java/joist/util/ExecuteTest.java
@@ -5,11 +5,12 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
+import java.nio.charset.Charset;
+
+import org.junit.Test;
 
 import joist.util.Execute.BufferedResult;
 import joist.util.Execute.Result;
-
-import org.junit.Test;
 
 public class ExecuteTest {
 
@@ -58,7 +59,7 @@ public class ExecuteTest {
     Result r = e.toFile("build/out.txt");
     assertThat(r.success, is(true));
     assertThat(r.exitValue, is(0));
-    assertThat(Read.fromFile(out).contains("README.markdown"), is(true));
+    assertThat(Read.fromFile(out, Charset.defaultCharset()).contains("README.markdown"), is(true));
   }
 
   @Test

--- a/util/src/test/java/joist/util/WriteTest.java
+++ b/util/src/test/java/joist/util/WriteTest.java
@@ -1,6 +1,9 @@
 package joist.util;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -11,8 +14,24 @@ public class WriteTest {
   public void testClasspathResourceToFile() {
     File d = Write.classpathResourceToTempFile("/joist/util/WriteTest.txt");
     System.out.println(d);
-    String contents = Read.fromFile(d);
+    String contents = Read.fromFile(d, Charset.defaultCharset());
     Assert.assertEquals("foo", contents);
+  }
+
+  @Test
+  public void testClasspathResourceToFileWithDefaultEncoding() throws IOException {
+    File tmpFile = File.createTempFile("junit", ".txt");
+    Write.toFile(tmpFile, "abcåäö", Charset.defaultCharset());
+    String contents = Read.fromFile(tmpFile, Charset.defaultCharset());
+    Assert.assertEquals("abcåäö", contents);
+  }
+
+  @Test
+  public void testClasspathResourceToFileWithUtf8Encoding() throws IOException {
+    File tmpFile = File.createTempFile("junit", ".txt");
+    Write.toFile(tmpFile, "abcåäö", StandardCharsets.UTF_8);
+    String contents = Read.fromFile(tmpFile, StandardCharsets.UTF_8);
+    Assert.assertEquals("abcåäö", contents);
   }
 
 }


### PR DESCRIPTION
Fixes issue #17 

Added a second constructor to GDirectory which has an extra Charset argument. Added Charset to Read and Write methods. **Note** that `joist.util.Read.fromInputStream(InputStream)` did have the encoding hardcoded to UTF-8 and is now **not** backward compatible.