### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,3 +49,26 @@ task wrapper(type: Wrapper) {
     gradleVersion = '4.10'
 }
 
+
+allprojects {    tasks.withType(Test).configureEach {
+        maxParallelForks = 4
+    }
+
+    tasks.withType(Test).configureEach {
+        forkEvery = 100
+    }
+
+    tasks.withType(Test).configureEach {
+        reports.html.required = false
+        reports.junitXml.required = false
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+        options.fork = true
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+        options.incremental = true
+    }
+
+}


### PR DESCRIPTION

[Parallel test execution maxParallelForks](https://docs.gradle.org/current/userguide/performance.html#parallel_test_execution), running multiple test cases in parallel is useful and helpful when there are several CPU cores.

According to [Process forking options](https://docs.gradle.org/current/userguide/performance.html#forking_options), Gradle will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones.
one option is to fork a new test VM after a certain number of tests have run. So we can do this with the forkEvery setting

[Disable report generation](https://docs.gradle.org/current/userguide/performance.html#report_generation), Gradle will automatically create test reports by default which will slowing down the overall build. So it's better to disable the test reports while we don't need it

[Compiler daemon](https://docs.gradle.org/current/userguide/performance.html#compiler_daemon), we can run the compiler as a separate process by this Gradle Java plugin to get a short compilation time.

[Incremental compilation](https://docs.gradle.org/current/userguide/performance.html#incremental_compilation), Gradle can analyze dependencies down to the individual class level in order to recompile only the classes that were affected by a change

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
